### PR TITLE
Fix overflow in storing motor power value

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@
 ## You should have received a copy of the GNU Lesser General Public License
 ## along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ##
-FW_VER ?= 4.4
+FW_VER ?= 4.4.1
 
 # Name of C file with main function
 BINARY = main

--- a/src/output.c
+++ b/src/output.c
@@ -129,7 +129,7 @@ bool output_enabled(uint8_t output_num) {
     return output_data[output_num].enabled;
 }
 
-int8_t output_get_output(uint8_t output_num) {
+int16_t output_get_output(uint8_t output_num) {
     if (!(output_num < NUM_OUTPUTS)) {
         // skip invalid output numbers
         return 0;

--- a/src/output.h
+++ b/src/output.h
@@ -9,7 +9,7 @@
 
 typedef struct {
     bool enabled;
-    int8_t value;
+    int16_t value;
     bool in_fault;
     uint16_t current;
 } output_t;
@@ -20,7 +20,7 @@ void output_init(void);
 
 void output_set_power(uint8_t output_num, int16_t output_val);
 bool output_enabled(uint8_t output_num);
-int8_t output_get_output(uint8_t output_num);
+int16_t output_get_output(uint8_t output_num);
 void output_disable(uint8_t output_num);
 uint16_t output_get_current(uint8_t output_num);
 void check_output_faults(void);


### PR DESCRIPTION
In version 4.4 reading the motor value returns incorrect values when the power is set outside the range -128/127.